### PR TITLE
Flatpak: Revoke access to AccountsService

### DIFF
--- a/com.github.ryonakano.louper.yml
+++ b/com.github.ryonakano.louper.yml
@@ -7,8 +7,6 @@ finish-args:
   - '--share=ipc'
   - '--socket=wayland'
   - '--socket=fallback-x11'
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
 modules:
   - name: louper
     buildsystem: meson


### PR DESCRIPTION
We don't need this since Flatpak Platform 6.0.2
