### PR TITLE
chore: metainfo: Update license id

### DIFF
--- a/data/louper.metainfo.xml.in
+++ b/data/louper.metainfo.xml.in
@@ -5,7 +5,7 @@
   <launchable type="desktop-id">com.github.ryonakano.louper.desktop</launchable>
   <translation type="gettext">com.github.ryonakano.louper</translation>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
 
   <name translate="no">Louper</name>
   <summary>Magnify the selected text</summary>


### PR DESCRIPTION
Since `GPL-3.0+` is deprecated.

https://spdx.org/licenses/GPL-3.0+.html