### PR TITLE
refactor: Bind color preference

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -42,6 +42,28 @@ public class Application : Gtk.Application {
         set_accels_for_action ("app.quit", { "<Control>q", "Escape" });
     }
 
+    /**
+     * Follow elementary OS-wide dark preference
+     */
+    private void setup_style () {
+        var granite_settings = Granite.Settings.get_default ();
+        var gtk_settings = Gtk.Settings.get_default ();
+
+        granite_settings.bind_property ("prefers-color-scheme", gtk_settings, "gtk-application-prefer-dark-theme",
+            BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
+            ((binding, granite_prop, ref gtk_prop) => {
+                gtk_prop.set_boolean ((Granite.Settings.ColorScheme) granite_prop == Granite.Settings.ColorScheme.DARK);
+                return true;
+            })
+        );
+    }
+
+    protected override void startup () {
+        base.startup ();
+
+        setup_style ();
+    }
+
     protected override void activate () {
         if (window != null) {
             return;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -78,16 +78,6 @@ public class MainWindow : Gtk.ApplicationWindow {
             // See https://gitlab.gnome.org/GNOME/gtk/-/issues/1874#note_509304
             update_label_text.begin (magnified_label);
         });
-
-        // Follow elementary OS-wide dark preference
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        });
     }
 
     private async void update_label_text (Gtk.Label label_widget) {


### PR DESCRIPTION
Also move to Application class because this is application-wide settings and not only for the MainWindow