### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/com.github.ryonakano.louper.yml
+++ b/com.github.ryonakano.louper.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.louper
+id: com.github.ryonakano.louper
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.