### PR TITLE
Actions: Use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   flatpak:
     name: Flatpak
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     container:
       image: valalang/lint


### PR DESCRIPTION
We run actions in the containers anyway so we don't need to fix the version of host distribution.
