### PR TITLE
refactor: MainWindow: Do not directory access to Application class

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,8 +4,8 @@
  */
 
 public class Application : Gtk.Application {
-    public static bool keep_open = false;
-    public static string? text = null;
+    private static bool keep_open = false;
+    private static string? text = null;
 
     private OptionEntry[] options = {
         {
@@ -70,7 +70,10 @@ public class Application : Gtk.Application {
             return;
         }
 
-        window = new MainWindow ();
+        window = new MainWindow () {
+            keep_open = keep_open,
+            text = text
+        };
         window.set_application (this);
         window.present ();
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -4,6 +4,9 @@
  */
 
 public class MainWindow : Gtk.ApplicationWindow {
+    public bool keep_open { get; set; }
+    public unowned string? text { get; set; }
+
     private const string CSS_DATA = """
     .magnified-text {
         font-size: 128px;
@@ -85,9 +88,9 @@ public class MainWindow : Gtk.ApplicationWindow {
     }
 
     private async void update_label_text (Gtk.Label label_widget) {
-        if (Application.text != null) {
+        if (text != null) {
             // Set the text passed by the command line option if specified
-            label_widget.label = Application.text;
+            label_widget.label = text;
         } else {
             // Otherwise set the text loaded from clipboard
             label_widget.label = yield load_clipboard ();
@@ -110,7 +113,7 @@ public class MainWindow : Gtk.ApplicationWindow {
     protected override void state_flags_changed (Gtk.StateFlags previous_state_flags) {
         Gtk.StateFlags current_state_flags = get_state_flags ();
         if (Gtk.StateFlags.BACKDROP in current_state_flags) {
-            if (Application.keep_open) {
+            if (keep_open) {
                 return;
             }
 


### PR DESCRIPTION
Give the data as input from an Application instance to a MainWindow instance instead of directory accessing to Application class.
