### PR TITLE
chore: metainfo: Remove deprecated developer_name

### DIFF
--- a/data/louper.metainfo.xml.in
+++ b/data/louper.metainfo.xml.in
@@ -50,8 +50,6 @@
   <url type="vcs-browser">https://github.com/ryonakano/louper</url>
   <url type="translate">https://hosted.weblate.org/projects/rosp</url>
 
-  <!-- developer_name has deprecated since AppStream 1.0 -->
-  <developer_name translate="no">Ryo Nakano</developer_name>
   <developer id="com.github.ryonakano">
     <name translate="no">Ryo Nakano</name>
   </developer>


### PR DESCRIPTION
Fixes #93
